### PR TITLE
Fix typo preventing save in sub-collection

### DIFF
--- a/addon/serializers/firestore.ts
+++ b/addon/serializers/firestore.ts
@@ -76,12 +76,12 @@ const normalizeRelationships = (store: DS.Store, modelClass: DS.Model, attribute
         included.splice(-1, 0, { links: { self: 'emberfire' }, ...data });
       }
     }
-    relationships[key] = normalizeRealtionship(relationship)(store, attribute, relationship, included);
+    relationships[key] = normalizeRelationship(relationship)(store, attribute, relationship, included);
   }, null);
   return {relationships, included};
 }
 
-const normalizeRealtionship = (relationship: any) => {
+const normalizeRelationship = (relationship: any) => {
   if (relationship.kind == 'belongsTo') {
     return normalizeBelongsTo;
   } else if (relationship.options.subcollection) {


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below and make note of the following:

Run the linter and test suite
==============================
Make sure your changes pass our linter and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual) before sending PRs. We cannot accept code without this.

-->


### Description

Fixes a typo that prevents sub-collections from saving. 
